### PR TITLE
添加Mock数据管理工具

### DIFF
--- a/backend/docs/mock-data-usage.md
+++ b/backend/docs/mock-data-usage.md
@@ -1,0 +1,89 @@
+# Mock数据管理工具使用指南
+
+这个文档介绍了如何使用mock数据管理工具进行测试和开发。
+
+## 概述
+
+`mock-data-manager.js` 是一个用于管理测试数据的工具，它可以将预定义的mock数据导入到数据库中，或者从数据库中删除这些数据。这对于测试和开发非常有用，因为它允许您快速设置一个包含测试数据的环境。
+
+## 数据来源
+
+mock数据存储在 `backend/data/mock-data.json` 文件中，包含以下几种类型的数据：
+
+1. **dataPoints**: 指标的历史数据点
+2. **upcomingEvents**: 即将发布的指标数据事件
+3. **historicalData**: 指标的历史数据序列
+
+## 使用方法
+
+### 前提条件
+
+确保您已经安装了所有必要的依赖：
+
+```bash
+cd backend
+npm install
+```
+
+### 命令
+
+在backend目录下运行以下命令：
+
+#### 导入mock数据
+
+```bash
+node src/utils/mock-data-manager.js import
+```
+
+这将把 `mock-data.json` 中的所有数据导入到数据库中。所有导入的数据都会被标记为测试数据，以便后续可以轻松删除。
+
+#### 删除mock数据
+
+```bash
+node src/utils/mock-data-manager.js delete
+```
+
+这将从数据库中删除所有标记为测试数据的记录。
+
+#### 重置mock数据
+
+```bash
+node src/utils/mock-data-manager.js reset
+```
+
+这将首先删除所有测试数据，然后重新导入mock数据。这对于恢复到一个干净的测试状态非常有用。
+
+#### 查看状态
+
+```bash
+node src/utils/mock-data-manager.js status
+```
+
+这将显示当前数据库中测试数据的状态，包括每种类型的数据有多少条记录。
+
+## 在代码中使用
+
+您也可以在自己的代码中导入并使用这个工具：
+
+```javascript
+const mockDataManager = require('../utils/mock-data-manager');
+
+// 导入mock数据
+await mockDataManager.importMockData();
+
+// 删除mock数据
+await mockDataManager.deleteMockData();
+
+// 重置mock数据
+await mockDataManager.resetMockData();
+
+// 查看状态
+await mockDataManager.showStatus();
+```
+
+## 注意事项
+
+1. 所有通过这个工具导入的数据都会被标记为测试数据（在数据库中有一个特殊的标记）
+2. 只有被标记为测试数据的记录才会被删除命令删除
+3. 这个工具会自动创建必要的表（如果它们不存在）
+4. 在生产环境中，建议不要使用这个工具，因为它可能会影响真实数据

--- a/backend/src/utils/database.js
+++ b/backend/src/utils/database.js
@@ -47,6 +47,7 @@ function initDatabase() {
       impact_level TEXT NOT NULL,
       change_direction TEXT NOT NULL,
       change_amount REAL NOT NULL,
+      source TEXT,
       FOREIGN KEY (indicator_id) REFERENCES indicators (id)
     )
   `, (err) => {

--- a/backend/src/utils/mock-data-manager.js
+++ b/backend/src/utils/mock-data-manager.js
@@ -1,0 +1,303 @@
+/**
+ * Mock数据管理工具
+ * 
+ * 这个脚本用于测试目的，可以将mock数据插入到数据库或从数据库中删除。
+ * 使用方法：
+ * - 导入数据: node mock-data-manager.js import
+ * - 删除数据: node mock-data-manager.js delete
+ * - 重置数据: node mock-data-manager.js reset
+ * - 查看状态: node mock-data-manager.js status
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { db, query, run } = require('./database');
+
+// 读取mock数据文件
+const mockDataPath = path.join(__dirname, '../../data/mock-data.json');
+const mockData = JSON.parse(fs.readFileSync(mockDataPath, 'utf8'));
+
+// 生成唯一的测试数据标识符（用于后续删除）
+const TEST_DATA_MARKER = 'MOCK_TEST_DATA';
+
+/**
+ * 导入mock数据到数据库
+ */
+async function importMockData() {
+  try {
+    console.log('开始导入mock数据...');
+    
+    // 1. 导入数据点
+    if (mockData.dataPoints && mockData.dataPoints.length > 0) {
+      console.log(`导入 ${mockData.dataPoints.length} 条数据点...`);
+      
+      for (const dataPoint of mockData.dataPoints) {
+        // 获取指标ID
+        const indicators = await query(
+          'SELECT id FROM indicators WHERE symbol = ?', 
+          [dataPoint.indicatorId]
+        );
+        
+        if (indicators.length === 0) {
+          console.warn(`找不到指标 ${dataPoint.indicatorId}，跳过相关数据点`);
+          continue;
+        }
+        
+        const indicatorId = indicators[0].id;
+        
+        // 插入数据点
+        await run(
+          `INSERT INTO data_points 
+           (indicator_id, release_date, actual_value, expected_value, previous_value, 
+            impact_level, change_direction, change_amount, source) 
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            indicatorId,
+            dataPoint.releaseDate,
+            dataPoint.actualValue,
+            dataPoint.expectedValue,
+            dataPoint.previousValue,
+            dataPoint.impactLevel,
+            dataPoint.changeDirection,
+            dataPoint.changeAmount,
+            TEST_DATA_MARKER // 标记为测试数据
+          ]
+        );
+      }
+      console.log('数据点导入完成');
+    }
+    
+    // 2. 导入即将发布的事件
+    if (mockData.upcomingEvents && mockData.upcomingEvents.length > 0) {
+      console.log(`导入 ${mockData.upcomingEvents.length} 条即将发布的事件...`);
+      
+      // 首先创建upcoming_events表（如果不存在）
+      await run(`
+        CREATE TABLE IF NOT EXISTS upcoming_events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          indicator_id TEXT NOT NULL,
+          release_date TEXT NOT NULL,
+          expected_value REAL,
+          importance TEXT,
+          description TEXT,
+          source TEXT
+        )
+      `);
+      
+      for (const event of mockData.upcomingEvents) {
+        // 插入即将发布的事件
+        await run(
+          `INSERT INTO upcoming_events 
+           (indicator_id, release_date, expected_value, importance, description, source) 
+           VALUES (?, ?, ?, ?, ?, ?)`,
+          [
+            event.indicatorId,
+            event.releaseDate,
+            event.expectedValue,
+            event.importance,
+            event.description,
+            TEST_DATA_MARKER // 标记为测试数据
+          ]
+        );
+      }
+      console.log('即将发布的事件导入完成');
+    }
+    
+    // 3. 导入历史数据
+    if (mockData.historicalData && mockData.historicalData.length > 0) {
+      console.log(`导入 ${mockData.historicalData.length} 条历史数据...`);
+      
+      // 首先创建historical_data表（如果不存在）
+      await run(`
+        CREATE TABLE IF NOT EXISTS historical_data (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          indicator_id TEXT NOT NULL,
+          date TEXT NOT NULL,
+          value REAL NOT NULL,
+          source TEXT
+        )
+      `);
+      
+      for (const data of mockData.historicalData) {
+        // 插入历史数据
+        await run(
+          `INSERT INTO historical_data 
+           (indicator_id, date, value, source) 
+           VALUES (?, ?, ?, ?)`,
+          [
+            data.indicatorId,
+            data.date,
+            data.value,
+            TEST_DATA_MARKER // 标记为测试数据
+          ]
+        );
+      }
+      console.log('历史数据导入完成');
+    }
+    
+    console.log('所有mock数据导入完成！');
+  } catch (error) {
+    console.error('导入mock数据时出错:', error);
+    throw error;
+  }
+}
+
+/**
+ * 从数据库中删除mock数据
+ */
+async function deleteMockData() {
+  try {
+    console.log('开始删除mock数据...');
+    
+    // 1. 删除数据点
+    const dataPointsResult = await run(
+      'DELETE FROM data_points WHERE source = ?',
+      [TEST_DATA_MARKER]
+    );
+    console.log(`已删除 ${dataPointsResult.changes} 条数据点`);
+    
+    // 2. 删除即将发布的事件（如果表存在）
+    try {
+      const upcomingEventsResult = await run(
+        'DELETE FROM upcoming_events WHERE source = ?',
+        [TEST_DATA_MARKER]
+      );
+      console.log(`已删除 ${upcomingEventsResult.changes} 条即将发布的事件`);
+    } catch (error) {
+      console.log('upcoming_events表可能不存在，跳过');
+    }
+    
+    // 3. 删除历史数据（如果表存在）
+    try {
+      const historicalDataResult = await run(
+        'DELETE FROM historical_data WHERE source = ?',
+        [TEST_DATA_MARKER]
+      );
+      console.log(`已删除 ${historicalDataResult.changes} 条历史数据`);
+    } catch (error) {
+      console.log('historical_data表可能不存在，跳过');
+    }
+    
+    console.log('所有mock数据删除完成！');
+  } catch (error) {
+    console.error('删除mock数据时出错:', error);
+    throw error;
+  }
+}
+
+/**
+ * 重置mock数据（先删除再导入）
+ */
+async function resetMockData() {
+  try {
+    await deleteMockData();
+    await importMockData();
+    console.log('Mock数据重置完成！');
+  } catch (error) {
+    console.error('重置mock数据时出错:', error);
+    throw error;
+  }
+}
+
+/**
+ * 显示当前mock数据状态
+ */
+async function showStatus() {
+  try {
+    console.log('当前mock数据状态:');
+    
+    // 1. 检查数据点
+    const dataPoints = await query(
+      'SELECT COUNT(*) as count FROM data_points WHERE source = ?',
+      [TEST_DATA_MARKER]
+    );
+    console.log(`- 数据点: ${dataPoints[0].count} 条`);
+    
+    // 2. 检查即将发布的事件
+    try {
+      const upcomingEvents = await query(
+        'SELECT COUNT(*) as count FROM upcoming_events WHERE source = ?',
+        [TEST_DATA_MARKER]
+      );
+      console.log(`- 即将发布的事件: ${upcomingEvents[0].count} 条`);
+    } catch (error) {
+      console.log('- 即将发布的事件: 表不存在');
+    }
+    
+    // 3. 检查历史数据
+    try {
+      const historicalData = await query(
+        'SELECT COUNT(*) as count FROM historical_data WHERE source = ?',
+        [TEST_DATA_MARKER]
+      );
+      console.log(`- 历史数据: ${historicalData[0].count} 条`);
+    } catch (error) {
+      console.log('- 历史数据: 表不存在');
+    }
+    
+    // 4. 显示数据库中的所有表
+    const tables = await query(
+      "SELECT name FROM sqlite_master WHERE type='table'"
+    );
+    console.log('- 数据库中的表:');
+    tables.forEach(table => {
+      console.log(`  * ${table.name}`);
+    });
+    
+  } catch (error) {
+    console.error('获取状态时出错:', error);
+    throw error;
+  }
+}
+
+/**
+ * 主函数
+ */
+async function main() {
+  const command = process.argv[2];
+  
+  if (!command) {
+    console.log('请指定命令: import, delete, reset, 或 status');
+    process.exit(1);
+  }
+  
+  try {
+    switch (command.toLowerCase()) {
+      case 'import':
+        await importMockData();
+        break;
+      case 'delete':
+        await deleteMockData();
+        break;
+      case 'reset':
+        await resetMockData();
+        break;
+      case 'status':
+        await showStatus();
+        break;
+      default:
+        console.log('未知命令。可用命令: import, delete, reset, 或 status');
+        process.exit(1);
+    }
+    
+    // 关闭数据库连接
+    db.close();
+    
+  } catch (error) {
+    console.error('执行命令时出错:', error);
+    process.exit(1);
+  }
+}
+
+// 如果直接运行此脚本，则执行main函数
+if (require.main === module) {
+  main();
+}
+
+// 导出函数以便其他模块使用
+module.exports = {
+  importMockData,
+  deleteMockData,
+  resetMockData,
+  showStatus
+};


### PR DESCRIPTION
## 功能描述

添加了一个Mock数据管理工具，用于测试目的，可以将mock数据插入到数据库或从数据库中删除。

## 实现细节

1. 创建了 `mock-data-manager.js` 脚本，提供以下功能：
   - 导入mock数据到数据库
   - 从数据库中删除mock数据
   - 重置mock数据（先删除再导入）
   - 显示当前mock数据状态

2. 修改了数据库模式，在 `data_points` 表中添加了 `source` 字段，用于标记测试数据

3. 添加了详细的使用文档 `backend/docs/mock-data-usage.md`

## 使用方法

在backend目录下运行以下命令：

```bash
# 导入mock数据
node src/utils/mock-data-manager.js import

# 删除mock数据
node src/utils/mock-data-manager.js delete

# 重置mock数据
node src/utils/mock-data-manager.js reset

# 查看状态
node src/utils/mock-data-manager.js status
```

## 优势

1. 便于测试：可以快速设置一个包含测试数据的环境
2. 数据隔离：测试数据被标记，不会与真实数据混淆
3. 易于清理：可以一键删除所有测试数据
4. 灵活性：支持多种类型的mock数据（数据点、即将发布的事件、历史数据）